### PR TITLE
Melhoria na implementação do método de consulta

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor
+.idea

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e2ad5616f433ba4302c9777bd964cd5",
+    "content-hash": "9b5094df83c13263bd00f9e28f64f771",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",

--- a/src/CEPFinder.php
+++ b/src/CEPFinder.php
@@ -2,6 +2,7 @@
 
 namespace GustavoFenilli\CEPFinder;
 
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Client;
 
@@ -22,21 +23,23 @@ class CEPFinder
     protected $gia;
 
     public function __construct($cep = null){
-        if($cep != null) $this->cep = $cep;
+        $this->cep = $cep;
 
         $this->client = new Client();
     }
 
     public function consult($cep = null)
     {
-        if(isset($this->cep)){
-            $cepEscoped = $this->cep;
-        }
-        
         if($cep != null){
             $cepEscoped = $cep;
+        } else {
+            $cepEscoped = $this->cep;
         }
 
+        if (!$cepEscoped) {
+            throw new \Exception("CEP não informado.");
+        }
+        
         try{
             $result = $this->client->get("viacep.com.br/ws/$cepEscoped/json/");
         }catch(GuzzleException $exception){


### PR DESCRIPTION
1. Não precisa validar se o parâmetro do construtor é != null, visto que o valor default do $this->cep já é null quando instanciando, então se o parâmetro for null não vai ter problema.
2. No método consult pode-se verificar antes se o parâmetro foi informado, senão usar o $this->cep. Antes da consulta é interessante verificar se o CEP para consultar foi definido, senão lançar Exception, evitando uma consulta desnecessária.